### PR TITLE
Makes docker config flexible

### DIFF
--- a/lib/higher-docker-manager.js
+++ b/lib/higher-docker-manager.js
@@ -11,7 +11,7 @@ const os = require('os');
 const selectn = require('selectn');
 const debug = require('debug')('HigherDockerManager:');
 
-const docker = new Docker({
+let docker = new Docker({
     socketPath: '/var/run/docker.sock'
 });
 
@@ -48,6 +48,7 @@ class HigherDockerManager {
      * @return {Promise} Promise returning pulled image
      * @api public
      */
+    
     static pullImage(auth, givenName, givenTag) {
         const { name, tag } = HigherDockerManager._getNameTag(givenName, givenTag);
 
@@ -401,6 +402,14 @@ class HigherDockerManager {
                 Detach: false
             }))
             .then(HigherDockerManager._processContainerOutputStream);
+    }
+     /**
+     * Changes docker configuration.
+     * @param {Object} `conf` Docker API config object see node-docker-api for reference.
+     * @api public
+     */
+    static setDocker(conf) {
+        docker = new Docker(conf)
     }
 
     /**


### PR DESCRIPTION
New method can change docker configuration, including docker socket file, or even connect using hostname and port
    HigherDockerManager.setDocker({ host: 'localhost', port: '2375'})